### PR TITLE
Fixes for compiler compliance, ImGUI reference update, and convenience script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+#######################
+# TODO (begin) #
+#######################
+# Change 'youruniqname' to match your UM uniqname (no quote marks).
+UNIQNAME    = morag
+
+# This is the path in Great Lakes to where projects will be
+# uploaded. By default goes to user's home directory.
+# Change this to select your preferred path.
+REMOTE_PATH := /nfs/turbo/coe-goroda/JANUS/GabrielMora/Sputterer
+
+#######################
+# TODO (end) #
+#######################
+
+# REMOTE_PATH has default definition above
+sync2arc:
+ifeq ($(UNIQNAME), youruniqname)
+	@echo Edit UNIQNAME variable in Makefile.
+	@exit 1;
+endif
+	# Synchronize local files into target directory on CAEN
+	rsync \
+      -av \
+      --exclude '*.o' \
+      --exclude '.git*' \
+      --exclude '.vs*' \
+      --exclude '*.code-workspace' \
+      --filter=":- .gitignore" \
+      "."/ \
+      "$(UNIQNAME)@greatlakes.arc-ts.umich.edu:$(REMOTE_PATH)/"
+	echo "Files synced to ARC at $(REMOTE_PATH)/"
+.PHONY: sync2arc
+# --delete \

--- a/src/Mesh.hpp
+++ b/src/Mesh.hpp
@@ -16,12 +16,30 @@ using std::string, std::vector;
 struct Vertex {
   vec3 pos;
   vec3 norm;
+
+  Vertex() = default;
+
+  Vertex(const glm::vec3& position, const glm::vec3& normal) {
+    pos = position;
+    norm = normal;
+  }
 };
 
 std::ostream &operator<< (std::ostream &os, const Vertex &v);
 
 struct TriElement {
   unsigned int i1, i2, i3;
+
+  TriElement() = default;
+
+  TriElement(int a, int b, int c) {
+    i1 = a, i2 = b, i3 = c;
+  }
+  
+  TriElement(unsigned long a, unsigned long b, unsigned long c) {
+    i1 = a, i2 = b, i3 = c;
+  }
+
 };
 
 std::ostream &operator<< (std::ostream &os, const TriElement &t);

--- a/src/ParticleContainer.cu
+++ b/src/ParticleContainer.cu
@@ -33,7 +33,12 @@ ParticleContainer::ParticleContainer (string name, size_t num, double mass, int 
 void
 ParticleContainer::add_particles (const host_vector<float3> &pos, const host_vector<float3> &vel
                                   , const host_vector<float> &w) {
-  auto n = static_cast<int>(std::min({pos.size(), vel.size(), w.size()}));
+  auto n = static_cast<int>(
+    std::min(
+      std::min(pos.size(), vel.size()), 
+      w.size()
+    )
+  );
   if (n == 0) return;
 
   position.resize(num_particles + n);
@@ -199,7 +204,7 @@ k_evolve (DeviceParticleContainer pc
       if (uniform < sticking_coeff) {
         // Particle sticks to surface
         pc.position[tid] = hit_pos;
-        pc.velocity[tid] = float3(0.0f, 0.0f, 0.0f);
+        pc.velocity[tid] = float3{0.0f, 0.0f, 0.0f};
 
         // Record that we hit this triangle
         atomicAdd(&collected[hit_triangle_id], 1);
@@ -337,8 +342,8 @@ void ParticleContainer::emit (Triangle &triangle, Emitter emitter, float dt) {
     // offset particle very slightly by norm
     auto tol = 0.0001f;
     pos[i] = pt + tol*norm;
-    auto jitter = float3(
-      rand_normal(0, emitter.spread), rand_normal(0, emitter.spread), rand_normal(0, emitter.spread));
+    auto jitter = float3{
+      rand_normal(0, emitter.spread), rand_normal(0, emitter.spread), rand_normal(0, emitter.spread)};
     vel[i] = emitter.velocity*(norm + jitter);
   }
 


### PR DESCRIPTION
ImGui:
- Upon trying to utilize github submodule, encountered following error:

```
fatal: remote error: upload-pack: not our ref 090f091e6940da71f8f3e34eeb0d1ec2859960a6
fatal: the remote end hung up unexpectedly
Fetched in submodule path 'imgui', but it did not contain 090f091e6940da71f8f3e34eeb0d1ec2859960a6. Direct fetching of that commit failed.
```
- Resolved by executing following commands:
```
cd imgui
git fetch --all
git checkout <new commit hash>
```

Fix(src/Mesh.hpp):
-  Encountered following errors when compiling Mesh.cpp. Solved by adding constructors.
```
Error 1: Mesh.hpp
In file included from /usr/include/x86_64-linux-gnu/c++/9/bits/c++allocator.h:33,
                 from /usr/include/c++/9/bits/allocator.h:46,
                 from /usr/include/c++/9/string:41,
                 from /usr/include/c++/9/bits/locale_classes.h:40,
                 from /usr/include/c++/9/bits/ios_base.h:41,
                 from /usr/include/c++/9/ios:42,
                 from /usr/include/c++/9/istream:38,
                 from /usr/include/c++/9/fstream:38,
                 from /Sputterer/src/Mesh.cpp:1:
/usr/include/c++/9/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = TriElement; _Args = {int, int, int}; _Tp = TriElement]’:
/usr/include/c++/9/bits/alloc_traits.h:483:4:   required from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = TriElement; _Args = {int, int, int}; _Tp = TriElement; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<TriElement>]’
/usr/include/c++/9/bits/vector.tcc:115:30:   required from ‘std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {int, int, int}; _Tp = TriElement; _Alloc = std::allocator<TriElement>; std::vector<_Tp, _Alloc>::reference = TriElement&]’
/Sputterer/src/Mesh.cpp:90:57:   required from here
/usr/include/c++/9/ext/new_allocator.h:146:4: error: new initializer expression list treated as compound expression [-fpermissive]
  146 |  { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/9/ext/new_allocator.h:146:4: error: no matching function for call to ‘TriElement::TriElement(int)’
In file included from /Sputterer/src/Mesh.cpp:6:
/Sputterer/src/Mesh.hpp:23:8: note: candidate: ‘TriElement::TriElement()’
   23 | struct TriElement {
      |        ^~~~~~~~~~
/Sputterer/src/Mesh.hpp:23:8: note:   candidate expects 0 arguments, 1 provided
/Sputterer/src/Mesh.hpp:23:8: note: candidate: ‘constexpr TriElement::TriElement(const TriElement&)’
/Sputterer/src/Mesh.hpp:23:8: note:   no known conversion for argument 1 from ‘int’ to ‘const TriElement&’
/Sputterer/src/Mesh.hpp:23:8: note: candidate: ‘constexpr TriElement::TriElement(TriElement&&)’
/Sputterer/src/Mesh.hpp:23:8: note:   no known conversion for argument 1 from ‘int’ to ‘TriElement&&’
In file included from /usr/include/x86_64-linux-gnu/c++/9/bits/c++allocator.h:33,
                 from /usr/include/c++/9/bits/allocator.h:46,
                 from /usr/include/c++/9/string:41,
                 from /usr/include/c++/9/bits/locale_classes.h:40,
                 from /usr/include/c++/9/bits/ios_base.h:41,
                 from /usr/include/c++/9/ios:42,
                 from /usr/include/c++/9/istream:38,
                 from /usr/include/c++/9/fstream:38,
                 from /Sputterer/src/Mesh.cpp:1:
/usr/include/c++/9/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = Vertex; _Args = {glm::vec<3, float, glm::packed_highp>&, glm::vec<3, float, glm::packed_highp>&}; _Tp = Vertex]’:
/usr/include/c++/9/bits/alloc_traits.h:483:4:   required from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = Vertex; _Args = {glm::vec<3, float, glm::packed_highp>&, glm::vec<3, float, glm::packed_highp>&}; _Tp = Vertex; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<Vertex>]’
/usr/include/c++/9/bits/vector.tcc:115:30:   required from ‘std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {glm::vec<3, float, glm::packed_highp>&, glm::vec<3, float, glm::packed_highp>&}; _Tp = Vertex; _Alloc = std::allocator<Vertex>; std::vector<_Tp, _Alloc>::reference = Vertex&]’
/Sputterer/src/Mesh.cpp:143:33:   required from here
/usr/include/c++/9/ext/new_allocator.h:146:4: error: no matching function for call to ‘Vertex::Vertex(glm::vec<3, float, glm::packed_highp>&, glm::vec<3, float, glm::packed_highp>&)’
  146 |  { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /Sputterer/src/Mesh.cpp:6:
/Sputterer/src/Mesh.hpp:16:8: note: candidate: ‘Vertex::Vertex()’
   16 | struct Vertex {
      |        ^~~~~~
Sputterer/src/Mesh.hpp:16:8: note:   candidate expects 0 arguments, 2 provided
Sputterer/src/Mesh.hpp:16:8: note: candidate: ‘constexpr Vertex::Vertex(const Vertex&)’
Sputterer/src/Mesh.hpp:16:8: note:   candidate expects 1 argument, 2 provided
/Sputterer/src/Mesh.hpp:16:8: note: candidate: ‘constexpr Vertex::Vertex(Vertex&&)’
/Sputterer/src/Mesh.hpp:16:8: note:   candidate expects 1 argument, 2 provided
In file included from /usr/include/x86_64-linux-gnu/c++/9/bits/c++allocator.h:33,
                 from /usr/include/c++/9/bits/allocator.h:46,
                 from /usr/include/c++/9/string:41,
                 from /usr/include/c++/9/bits/locale_classes.h:40,
                 from /usr/include/c++/9/bits/ios_base.h:41,
                 from /usr/include/c++/9/ios:42,
                 from /usr/include/c++/9/istream:38,
                 from /usr/include/c++/9/fstream:38,
                 from /Sputterer/src/Mesh.cpp:1:
/usr/include/c++/9/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = TriElement; _Args = {long unsigned int&, long unsigned int, long unsigned int}; _Tp = TriElement]’:
/usr/include/c++/9/bits/alloc_traits.h:483:4:   required from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = TriElement; _Args = {long unsigned int&, long unsigned int, long unsigned int}; _Tp = TriElement; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<TriElement>]’
/usr/include/c++/9/bits/vector.tcc:115:30:   required from ‘std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {long unsigned int&, long unsigned int, long unsigned int}; _Tp = TriElement; _Alloc = std::allocator<TriElement>; std::vector<_Tp, _Alloc>::reference = TriElement&]’
/Sputterer/src/Mesh.cpp:148:78:   required from here
/usr/include/c++/9/ext/new_allocator.h:146:4: error: new initializer expression list treated as compound expression [-fpermissive]
  146 |  { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/9/ext/new_allocator.h:146:4: error: no matching function for call to ‘TriElement::TriElement(long unsigned int)’
In file included from /Sputterer/src/Mesh.cpp:6:
/Sputterer/src/Mesh.hpp:23:8: note: candidate: ‘TriElement::TriElement()’
   23 | struct TriElement {
      |        ^~~~~~~~~~
/Sputterer/src/Mesh.hpp:23:8: note:   candidate expects 0 arguments, 1 provided
/Sputterer/src/Mesh.hpp:23:8: note: candidate: ‘constexpr TriElement::TriElement(const TriElement&)’
/Sputterer/src/Mesh.hpp:23:8: note:   no known conversion for argument 1 from ‘long unsigned int’ to ‘const TriElement&’
/Sputterer/src/Mesh.hpp:23:8: note: candidate: ‘constexpr TriElement::TriElement(TriElement&&)’
/Sputterer/src/Mesh.hpp:23:8: note:   no known conversion for argument 1 from ‘long unsigned int’ to ‘TriElement&&’
```

Fix(src/ParticleContainer.cu):
-  Encountered following errors when compiling ParticleContainer.cu. Solved by changing syntax slightly.
```
/Sputterer/src/ParticleContainer.cu(36): error: no instance of overloaded function "std::min" matches the argument list
            argument types are: ({...})
    auto n = static_cast<int>(std::min({pos.size(), vel.size(), w.size()}));
                              ^
/usr/include/c++/9/bits/stl_algobase.h(246): note #3322-D: number of parameters of function template "std::min(const _Tp &, const _Tp &, _Compare)" does not match the call
      min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      ^
/usr/include/c++/9/bits/stl_algobase.h(198): note #3322-D: number of parameters of function template "std::min(const _Tp &, const _Tp &)" does not match the call
      min(const _Tp& __a, const _Tp& __b)
      ^

/Sputterer/src/ParticleContainer.cu(181): warning #3356-D: structured bindings are a C++17 feature
        auto &[_, t, hit_pos, norm, hit_triangle_id] = closest_hit;
              ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/Sputterer/src/ParticleContainer.cu(202): error: no suitable constructor exists to convert from "float" to "float3"
          pc.velocity[tid] = float3(0.0f, 0.0f, 0.0f);
                                    ^

/Sputterer/src/ParticleContainer.cu(202): error: expected a ")"
          pc.velocity[tid] = float3(0.0f, 0.0f, 0.0f);
                                        ^

/Sputterer/src/ParticleContainer.cu(288): warning #3356-D: structured bindings are a C++17 feature
    auto [grid, block] = get_kernel_launch_params(num_particles + hits.size());
         ^

/Sputterer/src/ParticleContainer.cu(341): error: no suitable constructor exists to convert from "float" to "float3"
        rand_normal(0, emitter.spread), rand_normal(0, emitter.spread), rand_normal(0, emitter.spread));
        ^

/Sputterer/src/ParticleContainer.cu(341): error: expected a ")"
        rand_normal(0, emitter.spread), rand_normal(0, emitter.spread), rand_normal(0, emitter.spread));
                                      ^

/Sputterer/src/ParticleContainer.cu(361): warning #3356-D: structured bindings are a C++17 feature
    auto [grid, block] = get_kernel_launch_params(num_particles);
         ^
```

Feat(Makefile): Simple makefile to push updates to Turbo quickly.